### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ The application allows you to manage SSL Certificates issued by Let’s Encrypt 
 ![ScreenShot](http://genia.sk/wp-content/uploads/2016/01/022.png)
 
 
-##Requirements##
+## Requirements ##
 - Let's Encrypt ACME client, that is configured and able to issue certificates
 - python
 - CherryPy
 - Some other Python libs
 - openssl installed
 
-##Basic features##
+## Basic features ##
 - WEB GUI for overview and easy management
 - HTTP API for automation
 - Creating / Revoking / Re-Issuing of certificates via API
@@ -21,7 +21,7 @@ The application allows you to manage SSL Certificates issued by Let’s Encrypt 
 - Limiting Access for specific IP addressed
 
 
-##Installation##
+## Installation ##
 The application was developed and tested on Debian Linux.
 - Clone the repository.
 - Edit the ALLOW_IPs=["x.x.x.x"] in file app.py
@@ -30,11 +30,11 @@ The application was developed and tested on Debian Linux.
 On the first run, the application will create the required SQLite database file.
 Navigate your browser to: http://x.x.x.x:9181/ to access the GUI.
 
-##Domain Validation (Authentication) via Webroot##
+## Domain Validation (Authentication) via Webroot ##
 To be able to issue certificates you shoud run an Apache server with empty webroot. (default on Debian)
 Then redirect all request from http://domain-to-issue.tld/.well-known/acme-challenge to the same machine where you host the Management application.
 
-###NGINX Config example###
+### NGINX Config example ###
 	location /.well-known/acme-challenge{
 	    proxy_redirect off;
 	    proxy_pass http://x.x.x.x:80;
@@ -43,13 +43,13 @@ Then redirect all request from http://domain-to-issue.tld/.well-known/acme-chall
 	    }
 
 
-##Documentation##
+## Documentation ##
 The documentation for API calls are included in the application itself. Look for the “API Documentation” tab in main menu.
 
 Have fun!
 
 
-##Comercial Support and Advanced features##
+## Comercial Support and Advanced features ##
 We also maintain an Advanced version fork that has the following features:
 - Email notifications (Informations and Errors while issuing certificates).
 - Maintenance module (designed to simplify management for Webhosters).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
